### PR TITLE
Fix a comment in values.yaml

### DIFF
--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -461,7 +461,7 @@ kubeclarity-postgresql-secret:
   # PostgreSQL host under hostKey
   # PostgreSQL port under portKey
   # PostgreSQL database name under databaseKey
-  # SSL mode under sslmodeKey (disable/enable)
+  # SSL mode under sslmodeKey (disable/require)
   create: true
   secretKey: "postgres-password"
   usernameKey: "postgres-username"


### PR DESCRIPTION
## Description

Correct misleading comment about 'sslmode' in the Postgres connection string. The previous suggestion caused confusion and connection errors. For reference, valid 'sslmode' options can be found [here](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).

## Type of Change

[ ] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[x] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
